### PR TITLE
Log exception detail on login failure

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -85,6 +85,7 @@ def login():
             flash('Invalid username or password', 'error')
             return redirect(url_for('auth.login'))
         except Exception as e:
+            current_app.logger.exception(f"Login error: {e}")
             flash('Please try again.', 'error')
             return redirect(url_for('auth.login'))
 


### PR DESCRIPTION
## Summary
- Adds `current_app.logger.exception()` to the generic `except` block in the login route so Cognito auth errors appear in `docker compose logs` instead of being silently swallowed

## Why
Debugging a login failure on a fresh EC2 deployment — the "Please try again" flash message gave no indication of the underlying cause (likely a Cognito client secret / misconfigured env var). Without this logging, diagnosing auth issues requires guesswork.

## Reviewer notes
- No behaviour change for end users — error flash message is unchanged
- The logged traceback will appear in gunicorn's stderr output (visible via `docker compose logs web`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)